### PR TITLE
Detect Rokit Installation and don't suggest Aftman with it

### DIFF
--- a/src/commands/openMenu.ts
+++ b/src/commands/openMenu.ts
@@ -88,7 +88,7 @@ function showSwitchMessage(install: RojoInstall) {
   const installType = install.installType
 
   // Tell the user about Aftman once per session
-  if (installType !== InstallType.aftman && !aftmanMessageSent) {
+  if (!(installType === InstallType.aftman || installType === InstallType.rokit) && !aftmanMessageSent) {
     aftmanMessageSent = true
 
     let details = ""

--- a/src/getRojoInstall.ts
+++ b/src/getRojoInstall.ts
@@ -8,6 +8,7 @@ import path = require("path")
 const exec = promisify(childProcess.exec)
 
 export enum InstallType {
+  rokit = "Rokit",
   aftman = "Aftman",
   foreman = "Foreman",
   global = "global",
@@ -25,7 +26,9 @@ type ExecError = {
 }
 
 function getInstallType(resolvedPath: string) {
-  if (resolvedPath.includes(".aftman")) {
+  if (resolvedPath.includes(".rokit")) {
+    return InstallType.rokit
+  } else if (resolvedPath.includes(".aftman")) {
     return InstallType.aftman
   } else if (resolvedPath.includes(".foreman")) {
     return InstallType.foreman
@@ -79,7 +82,7 @@ export async function getRojoInstall(
       resolvedPath,
     }
   } else {
-    if (outputResult.error.stderr.includes("aftman")) {
+    if (outputResult.error.stderr.includes("aftman") || outputResult.error.stderr.includes("rokit")) {
       return null
     }
 


### PR DESCRIPTION
Added Rokit as an Install Type and turned off suggestion to switch to Aftman because it was being detected as globally installed

![image](https://github.com/user-attachments/assets/b85d47b3-5947-4f78-924f-e415ba97f886)
