### PR TITLE
Fix project schema generation being skipped by the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 - Webpack build failure with dist directory creation
 - Tool detection to avoid suggesting Aftman when Rokit is installed
+- Project schema generation is now awaited by the build, so `project.schema.json`
+  can no longer be missing from a bundle that built successfully
+- Failures while downloading the Roblox API dump now fail the build with an
+  error message instead of being silently ignored
 
 ## [2.1.2] - 2022-08-25
 ### Fixed

--- a/plugins/GenerateSchemaPlugin.js
+++ b/plugins/GenerateSchemaPlugin.js
@@ -5,21 +5,33 @@ const API_DUMP_URL = "https://raw.githubusercontent.com/CloneTrooper1019/Roblox-
 
 function getAPIDump() {
 	return new Promise((resolve, reject) => {
-		const req = https.get(API_DUMP_URL, res => {
+		https.get(API_DUMP_URL, res => {
+			if (res.statusCode !== 200) {
+				res.resume()
+				reject(new Error(
+					`Could not download the Roblox API dump from ${API_DUMP_URL}: server responded with status ${res.statusCode}`
+				))
+				return
+			}
+
 			let raw = ""
 
+			res.setEncoding("utf8")
+
 			res.on('data', chunk => {
-				raw += chunk;
+				raw += chunk
 			})
 
 			res.on('end', () => {
-				const data = JSON.parse(raw);
-				resolve(data)
+				try {
+					resolve(JSON.parse(raw))
+				} catch (err) {
+					reject(new Error(`Could not parse the Roblox API dump: ${err.message}`))
+				}
 			})
 
-		}).on('error', err => reject)
-
-		req.end()
+			res.on('error', reject)
+		}).on('error', reject)
 	})
 }
 
@@ -76,9 +88,9 @@ async function generateSchema() {
 
 module.exports = class GenerateSchemaPlugin {
 	apply(compiler) {
-		// Generate the schema by reading the template, adding dynamic content, and writing to the main file location
-		compiler.hooks.compile.tap("GenerateSchema", async () => {
-			generateSchema()
-		})
+		// Generate the schema by reading the template, adding dynamic content, and writing to the main file location.
+		// `beforeCompile` is an async hook, so tapping it with a promise makes webpack wait for the schema to be
+		// written before the build continues. `compile` is synchronous and would let the build finish first.
+		compiler.hooks.beforeCompile.tapPromise("GenerateSchema", () => generateSchema())
 	}
 }


### PR DESCRIPTION
# Fix project schema generation being skipped by the build

Related to #97.

## Problem

`plugins/GenerateSchemaPlugin.js` writes `dist/project.schema.json`, which is the
file `contributes.jsonValidation` points at for `*.project.json` and
`*.project.jsonc`. Two bugs mean that file can be missing or stale in a build
that otherwise reports success.

**1. The build never waits for the schema to be written.**

```js
compiler.hooks.compile.tap("GenerateSchema", async () => {
  generateSchema()
})
```

`compile` is a `SyncHook`, so the async callback's promise is dropped on the
floor. Schema generation makes a network request for the Roblox API dump, so it
almost always finishes after the bundle does. Whether `dist/project.schema.json`
exists at the end of `npm run package` comes down to timing.

**2. Download failures are silent.**

```js
}).on('error', err => reject)
```

The handler returns `reject` instead of calling it, so a network error leaves
the promise pending forever. And a non-200 response falls through to
`JSON.parse` on the error page, throwing a `SyntaxError` from inside the
response callback rather than rejecting.

Because of bug 1, neither failure mode is visible: nothing is awaited, so
nothing surfaces the error.

## Fix

- Tap `beforeCompile` with `tapPromise` so webpack waits for the schema.
- Call `reject(err)` on socket errors and reject on non-200 responses.
- Wrap `JSON.parse` in try/catch and reject with a clear message.

A failed API dump download now fails the build instead of quietly producing a
bundle with no schema, which seems like the right trade for a file the extension
depends on.

## Testing

- `generateSchema()` against the live API dump produces
  `dist/project.schema.json` (~36 KB, 326 services, 898 classes).
- Pointing `API_DUMP_URL` at a nonexistent path: this branch rejects with
  `server responded with status 404`; `master` throws an uncaught `SyntaxError`
  and the promise is never settled.

## Notes

- Kept the file's existing tab indentation to keep the diff readable, even
  though `.editorconfig` asks for 2 spaces on `*.js`. Happy to reformat the file
  separately if you'd prefer.
- I couldn't reproduce #97 on vscode-oss directly. This is the most likely cause
  I could find — a published `.vsix` that lost the race would ship without a
  schema — but I'd rather you treat this as "probably fixes" than have me claim
  it closes the issue.

---

## Optional comment to leave on issue #97 before opening the PR

> I think I found a likely cause for this. The schema is generated at build time
> by `GenerateSchemaPlugin`, which taps webpack's synchronous `compile` hook with
> an async callback — so the build never waits for `dist/project.schema.json` to
> be written, and any error downloading the Roblox API dump is swallowed (the
> `error` handler returns `reject` instead of calling it). That would produce a
> published build with no schema and no error anywhere. Happy to open a PR if
> that sounds right.